### PR TITLE
Add folder selection dialog for memory dump

### DIFF
--- a/src/sdl3/osd.cpp
+++ b/src/sdl3/osd.cpp
@@ -268,6 +268,7 @@ OSD::OSD() {
   show_menu = true;
   show_file_browser = false;
   show_save_browser = false;
+  pending_memdump = false;
   imgui_initialized = false;
   ui_interacting = false;
   ui_interacting_reason = UI_REASON_NONE;
@@ -1057,7 +1058,28 @@ int OSD::draw_screen() {
       menu_height = ImGui::GetFrameHeight();
       ImGui::EndMainMenuBar();
     }
-  
+
+    // Process pending memory dump from folder dialog callback
+    if (pending_memdump && !pending_memdump_dir.empty()) {
+      std::time_t t = std::time(nullptr);
+      std::tm tm_local;
+#if defined(_WIN32)
+      localtime_s(&tm_local, &t);
+#else
+      localtime_r(&t, &tm_local);
+#endif
+      char stamp[32];
+      std::strftime(stamp, sizeof(stamp), "%Y%m%d_%H%M%S", &tm_local);
+      std::string dir = pending_memdump_dir + "/BubiC_memdump_" + stamp;
+      bool ok = vm ? vm->dump_memory(dir.c_str()) : false;
+      fprintf(stderr, "%s %s\n",
+              ok ? "Memory dump written to"
+                 : "Memory dump FAILED at",
+              dir.c_str());
+      pending_memdump = false;
+      pending_memdump_dir.clear();
+    }
+
     // Draw Status Bar at the bottom
     const float status_height = 24.0f;
     if (ui_visible) {
@@ -1770,23 +1792,16 @@ bool OSD::draw_menu_contents() {
       ImGui::Separator();
       if (ImGui::MenuItem("Dump Memory...")) {
         if (vm) {
-          // Build dump directory: $HOME/BubiC_memdump_YYYYMMDD_HHMMSS/
-          std::time_t t = std::time(nullptr);
-          std::tm tm_local;
-#if defined(_WIN32)
-          localtime_s(&tm_local, &t);
-#else
-          localtime_r(&t, &tm_local);
-#endif
-          char stamp[32];
-          std::strftime(stamp, sizeof(stamp), "%Y%m%d_%H%M%S", &tm_local);
           std::string home = get_home_directory();
-          std::string dir = home + "/BubiC_memdump_" + stamp;
-          bool ok = vm->dump_memory(dir.c_str());
-          fprintf(stderr, "%s %s\n",
-                  ok ? "Memory dump written to"
-                     : "Memory dump FAILED at",
-                  dir.c_str());
+          pending_memdump = true;
+          SDL_ShowOpenFolderDialog([](void *userdata, const char * const *filelist, int filter) {
+            OSD *osd = static_cast<OSD*>(userdata);
+            if (filelist && filelist[0]) {
+              osd->pending_memdump_dir = filelist[0];
+            } else {
+              osd->pending_memdump = false;
+            }
+          }, this, window, home.c_str(), false);
         }
       }
       ImGui::EndMenu();

--- a/src/sdl3/osd.cpp
+++ b/src/sdl3/osd.cpp
@@ -1767,6 +1767,28 @@ bool OSD::draw_menu_contents() {
         }
         ImGui::EndMenu();
       }
+      ImGui::Separator();
+      if (ImGui::MenuItem("Dump Memory...")) {
+        if (vm) {
+          // Build dump directory: $HOME/BubiC_memdump_YYYYMMDD_HHMMSS/
+          std::time_t t = std::time(nullptr);
+          std::tm tm_local;
+#if defined(_WIN32)
+          localtime_s(&tm_local, &t);
+#else
+          localtime_r(&t, &tm_local);
+#endif
+          char stamp[32];
+          std::strftime(stamp, sizeof(stamp), "%Y%m%d_%H%M%S", &tm_local);
+          std::string home = get_home_directory();
+          std::string dir = home + "/BubiC_memdump_" + stamp;
+          bool ok = vm->dump_memory(dir.c_str());
+          fprintf(stderr, "%s %s\n",
+                  ok ? "Memory dump written to"
+                     : "Memory dump FAILED at",
+                  dir.c_str());
+        }
+      }
       ImGui::EndMenu();
     }
     return menu_tree_open;

--- a/src/sdl3/osd.h
+++ b/src/sdl3/osd.h
@@ -8,6 +8,7 @@
 #include "../common.h"
 #include "../vm/vm.h"
 #include <SDL3/SDL.h>
+#include <string>
 
 // SDL3 specific definitions
 #define OSD_CONSOLE_BLUE 1
@@ -102,6 +103,8 @@ private:
   bool show_menu;
   bool show_file_browser;
   bool show_save_browser;
+  bool pending_memdump;
+  std::string pending_memdump_dir;
   bool imgui_initialized;
   uint64_t last_ui_interaction_tick;
   bool ui_interacting;

--- a/src/vm/pc80s31k.h
+++ b/src/vm/pc80s31k.h
@@ -62,6 +62,9 @@ public:
 	{
 		d_pio = device;
 	}
+	// Bubilator88 cross-emulator memory dump (see docs/MEMORY_DUMP_FORMAT.md)
+	const uint8_t* get_rom_ptr() const { return rom; }
+	const uint8_t* get_ram_ptr() const { return ram; }
 };
 
 #endif

--- a/src/vm/pc8801/pc88.h
+++ b/src/vm/pc8801/pc88.h
@@ -470,6 +470,20 @@ public:
 		return (n88rom[0x79d7] < 0x38);
 	}
 #endif
+	// Bubilator88 cross-emulator memory dump (see docs/MEMORY_DUMP_FORMAT.md)
+	const uint8_t* get_ram_ptr() const { return ram; }
+#if defined(SUPPORT_PC88_GVRAM)
+	const uint8_t* get_gvram_ptr() const { return gvram; }
+#endif
+#if defined(PC8801SR_VARIANT)
+	const uint8_t* get_tvram_ptr() const { return tvram; }
+#endif
+#if defined(PC88_EXRAM_BANKS)
+	const uint8_t* get_exram_ptr() const { return exram; }
+	int get_exram_banks() const { return PC88_EXRAM_BANKS; }
+#endif
+	bool is_cpu_clock_low() const { return cpu_clock_low; }
+
 	void set_context_cpu(Z80* device)
 	{
 		d_cpu = device;

--- a/src/vm/pc8801/pc8801.cpp
+++ b/src/vm/pc8801/pc8801.cpp
@@ -1284,3 +1284,131 @@ bool VM::process_state(FILEIO* state_fio, bool loading)
 	return true;
 }
 
+// ---------------------------------------------------------------------------
+// Bubilator88 cross-emulator memory dump.
+// Writes the PC-8801 memory regions as raw binary files into `dir_utf8`,
+// following the format specified in Bubilator88's docs/MEMORY_DUMP_FORMAT.md.
+// Used for byte-level `diff -r` comparison against Bubilator88 dumps.
+// ---------------------------------------------------------------------------
+
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <cerrno>
+#if defined(_WIN32)
+#include <direct.h>
+#endif
+
+namespace {
+static bool ensure_directory(const char* path)
+{
+#if defined(_WIN32)
+	int rc = _mkdir(path);
+#else
+	int rc = mkdir(path, 0755);
+#endif
+	if (rc == 0) return true;
+	if (errno == EEXIST) return true;
+	return false;
+}
+
+static bool write_raw_file(const char* dir, const char* name,
+                           const void* data, size_t size)
+{
+	char path[2048];
+	std::snprintf(path, sizeof(path), "%s/%s", dir, name);
+	FILE* fp = std::fopen(path, "wb");
+	if (!fp) return false;
+	size_t written = std::fwrite(data, 1, size, fp);
+	std::fclose(fp);
+	return written == size;
+}
+} // anonymous namespace
+
+bool VM::dump_memory(const char* dir_utf8)
+{
+	if (!dir_utf8 || !*dir_utf8) return false;
+	if (!ensure_directory(dir_utf8)) return false;
+	if (!pc88) return false;
+
+	// --- main.bin: 64KB main RAM -----------------------------------------
+	if (!write_raw_file(dir_utf8, "main.bin", pc88->get_ram_ptr(), 0x10000))
+		return false;
+
+#if defined(SUPPORT_PC88_GVRAM)
+	// --- gvram_{b,r,g}.bin: 16KB each ------------------------------------
+	// BubiC layout: plane 0 (B) at 0x0000, R at 0x4000, G at 0x8000
+	const uint8_t* gv = pc88->get_gvram_ptr();
+	if (!write_raw_file(dir_utf8, "gvram_b.bin", gv + 0x0000, 0x4000))
+		return false;
+	if (!write_raw_file(dir_utf8, "gvram_r.bin", gv + 0x4000, 0x4000))
+		return false;
+	if (!write_raw_file(dir_utf8, "gvram_g.bin", gv + 0x8000, 0x4000))
+		return false;
+#endif
+
+#if defined(PC8801SR_VARIANT)
+	// --- tvram.bin: 4KB text VRAM ----------------------------------------
+	if (!write_raw_file(dir_utf8, "tvram.bin", pc88->get_tvram_ptr(), 0x1000))
+		return false;
+#endif
+
+	// --- subram.bin: 32KB sub-CPU memory space ---------------------------
+	// Bubilator88 layout: 8KB DISK.ROM + 8KB pattern + 16KB RAM = 32KB
+	if (pc88sub) {
+		uint8_t buf[0x8000];
+		memset(buf, 0, sizeof(buf));
+		memcpy(buf + 0x0000, pc88sub->get_rom_ptr(), 0x2000);
+		// 0x2000-0x3FFF: unmapped in real HW (left as zero)
+		memcpy(buf + 0x4000, pc88sub->get_ram_ptr(), 0x4000);
+		if (!write_raw_file(dir_utf8, "subram.bin", buf, sizeof(buf)))
+			return false;
+	}
+
+#if defined(PC88_EXRAM_BANKS)
+	// --- extram_c0_b<N>.bin: 32KB per bank, one card ---------------------
+	const uint8_t* ex = pc88->get_exram_ptr();
+	int banks = pc88->get_exram_banks();
+	for (int b = 0; b < banks; b++) {
+		char name[32];
+		std::snprintf(name, sizeof(name), "extram_c0_b%d.bin", b);
+		if (!write_raw_file(dir_utf8, name, ex + (size_t)b * 0x8000, 0x8000))
+			return false;
+	}
+#endif
+
+	// --- info.txt: ISO8601 UTC timestamp + metadata ----------------------
+	{
+		char path[2048];
+		std::snprintf(path, sizeof(path), "%s/info.txt", dir_utf8);
+		FILE* fp = std::fopen(path, "w");
+		if (!fp) return false;
+
+		std::time_t t = std::time(nullptr);
+		std::tm tm_utc;
+#if defined(_WIN32)
+		gmtime_s(&tm_utc, &t);
+#else
+		gmtime_r(&t, &tm_utc);
+#endif
+		char ts[32];
+		std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
+
+		std::fprintf(fp, "emulator=BubiC-8801MA\n");
+		std::fprintf(fp, "format_version=1\n");
+		std::fprintf(fp, "timestamp=%s\n", ts);
+		std::fprintf(fp, "clock=%s\n", pc88->is_cpu_clock_low() ? "4MHz" : "8MHz");
+#if defined(PC88_EXRAM_BANKS)
+		std::fprintf(fp, "ext_ram=installed\n");
+#else
+		std::fprintf(fp, "ext_ram=none\n");
+#endif
+		std::fprintf(fp, "boot_mode=%d\n", boot_mode);
+		std::fclose(fp);
+	}
+
+	return true;
+}
+

--- a/src/vm/pc8801/pc8801.h
+++ b/src/vm/pc8801/pc8801.h
@@ -520,6 +520,11 @@ public:
 	
 	void update_config();
 	bool process_state(FILEIO* state_fio, bool loading);
+
+	// Bubilator88 cross-emulator memory dump (see docs/MEMORY_DUMP_FORMAT.md).
+	// Writes main/gvram/tvram/subram/extram/info.txt into `dir_utf8`.
+	// Returns true on success.
+	bool dump_memory(const char* dir_utf8);
 	
 	// ----------------------------------------
 	// for each device

--- a/src/vm/vm_template.h
+++ b/src/vm/vm_template.h
@@ -153,6 +153,9 @@ public:
 	
 	virtual void update_config() { }
 	virtual bool process_state(FILEIO* state_fio, bool loading) { return true; }
+
+	// Bubilator88 cross-emulator memory dump (see docs/MEMORY_DUMP_FORMAT.md).
+	virtual bool dump_memory(const char* dir_utf8) { return false; }
 	
 	// devices
 	virtual void set_cpu_clock(DEVICE *cpu, uint32_t clocks) { }


### PR DESCRIPTION
## Summary
- メモリダンプの保存先をSDL3の`SDL_ShowOpenFolderDialog`でユーザーが選択できるように変更
- ホームディレクトリ固定だった保存先を任意のフォルダに変更可能に

## Test plan
- [x] Host → Dump Memory... でフォルダ選択ダイアログが表示される
- [x] フォルダ選択後、タイムスタンプ付きサブディレクトリにメモリダンプが作成される
- [x] ダイアログをキャンセルした場合、何も起きない

🤖 Generated with [Claude Code](https://claude.com/claude-code)