### PR TITLE
Pause emulation while native file dialogs are open

### DIFF
--- a/src/sdl3/osd.cpp
+++ b/src/sdl3/osd.cpp
@@ -267,6 +267,7 @@ OSD::OSD() {
   key_caps_locked = false;
   show_menu = true;
   pending_memdump = false;
+  native_dialog_open = false;
   imgui_initialized = false;
   ui_interacting = false;
   ui_interacting_reason = UI_REASON_NONE;
@@ -1139,6 +1140,9 @@ int OSD::draw_screen() {
     if (menu_tree_open) {
       next_reason |= UI_REASON_MENU_TREE;
     }
+    if (native_dialog_open) {
+      next_reason |= UI_REASON_NATIVE_DIALOG;
+    }
     const bool next_ui_interacting = (next_reason != UI_REASON_NONE);
     if (!prev_ui_interacting && next_ui_interacting) {
       clear_all_pressed_keys();
@@ -1777,6 +1781,7 @@ bool OSD::draw_menu_contents() {
         if (vm) {
           std::string home = get_home_directory();
           pending_memdump = true;
+          native_dialog_open = true;
           SDL_ShowOpenFolderDialog([](void *userdata, const char * const *filelist, int filter) {
             OSD *osd = static_cast<OSD*>(userdata);
             if (filelist && filelist[0]) {
@@ -1784,6 +1789,7 @@ bool OSD::draw_menu_contents() {
             } else {
               osd->pending_memdump = false;
             }
+            osd->native_dialog_open = false;
           }, this, window, home.c_str(), false);
         }
       }
@@ -1816,11 +1822,13 @@ void OSD::select_file(int drive) {
   };
   std::string default_loc = tchar_path_to_utf8(config.last_browser_path);
   if (default_loc.empty()) default_loc = get_home_directory();
+  native_dialog_open = true;
   SDL_ShowOpenFileDialog([](void *userdata, const char * const *filelist, int filter) {
     OSD *osd = static_cast<OSD*>(userdata);
     if (filelist && filelist[0]) {
       osd->pending_insert_path = filelist[0];
     }
+    osd->native_dialog_open = false;
   }, this, window, filters, 2, default_loc.c_str(), false);
 }
 
@@ -1892,11 +1900,13 @@ void OSD::select_save_file(int drive, int type) {
   };
   std::string default_loc = tchar_path_to_utf8(config.last_browser_path);
   if (default_loc.empty()) default_loc = get_home_directory();
+  native_dialog_open = true;
   SDL_ShowSaveFileDialog([](void *userdata, const char * const *filelist, int filter) {
     OSD *osd = static_cast<OSD*>(userdata);
     if (filelist && filelist[0]) {
       osd->pending_save_path = filelist[0];
     }
+    osd->native_dialog_open = false;
   }, this, window, filters, 1, default_loc.c_str());
 }
 

--- a/src/sdl3/osd.h
+++ b/src/sdl3/osd.h
@@ -102,6 +102,7 @@ private:
   bool show_menu;
   bool pending_memdump;
   std::string pending_memdump_dir;
+  bool native_dialog_open;
   bool imgui_initialized;
   uint64_t last_ui_interaction_tick;
   bool ui_interacting;
@@ -145,6 +146,7 @@ public:
     UI_REASON_MENU_TREE = 1u << 0,
     UI_REASON_FILE_BROWSER = 1u << 1,
     UI_REASON_SAVE_BROWSER = 1u << 2,
+    UI_REASON_NATIVE_DIALOG = 1u << 3,
   };
   void force_unlock_vm() {}
   void sleep(uint32_t ms);


### PR DESCRIPTION
## Summary
- ネイティブSDL3ダイアログ（ファイル選択、保存、フォルダ選択）表示中にエミュレーションを一時停止するようにした
- メモリダンプやディスク操作時に、メニュー操作時点の正確なエミュレータ状態をキャプチャできるようになった
- `native_dialog_open` フラグと `UI_REASON_NATIVE_DIALOG` を既存の一時停止メカニズムに統合

## Test plan
- [x] ビルドが成功することを確認
- [x] ディスク選択ダイアログ表示中にエミュレーションが停止することを確認
- [x] 保存ダイアログ表示中にエミュレーションが停止することを確認
- [x] メモリダンプのフォルダ選択ダイアログ表示中にエミュレーションが停止することを確認
- [x] ダイアログを閉じた後にエミュレーションが正常に再開することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)