### PR TITLE
[codex] Add PC-88 mouse support

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -120,6 +120,8 @@ void initialize_config()
 	config.sound_frequency = 2;	// 55467Hz
 	config.sound_latency = 0;	// 50msec
 	config.master_volume = 100;
+	config.mouse_enabled = false;
+	config.mouse_sensitivity = 50;
 	config.sound_strict_rendering = true;
 	config.sound_mute_fm = false;
 	config.sound_mute_ssg = false;
@@ -202,7 +204,23 @@ void load_config(const _TCHAR* config_path)
 	#endif
 	#ifdef USE_JOYSTICK_TYPE
 		config.joystick_type = MyGetPrivateProfileInt(_T("Control"), _T("JoystickType"), config.joystick_type, config_path);
+		// Legacy SDL builds encoded mouse enable/mode entirely in JoystickType:
+		// 0=off/joystick, 1=bus mouse, 2=mouse-as-joystick.
+		config.mouse_enabled = MyGetPrivateProfileBool(
+			_T("Control"), _T("MouseEnabled"), config.joystick_type != 0, config_path);
+		if (config.joystick_type != 1 && config.joystick_type != 2) {
+			config.joystick_type = 1;
+		}
+	#else
+		config.mouse_enabled = MyGetPrivateProfileBool(
+			_T("Control"), _T("MouseEnabled"), config.mouse_enabled, config_path);
 	#endif
+	config.mouse_sensitivity = MyGetPrivateProfileInt(_T("Control"), _T("MouseSensitivity"), config.mouse_sensitivity, config_path);
+	if (config.mouse_sensitivity != 50 && config.mouse_sensitivity != 75 &&
+	    config.mouse_sensitivity != 100 && config.mouse_sensitivity != 150 &&
+	    config.mouse_sensitivity != 200 && config.mouse_sensitivity != 300) {
+		config.mouse_sensitivity = 50;
+	}
 	#ifdef USE_SOUND_TYPE
 		config.sound_type = MyGetPrivateProfileInt(_T("Control"), _T("SoundType"), config.sound_type, config_path);
 	#endif
@@ -469,6 +487,8 @@ void save_config(const _TCHAR* config_path)
 	#ifdef USE_JOYSTICK_TYPE
 		MyWritePrivateProfileInt(_T("Control"), _T("JoystickType"), config.joystick_type, config_path);
 	#endif
+	MyWritePrivateProfileBool(_T("Control"), _T("MouseEnabled"), config.mouse_enabled, config_path);
+	MyWritePrivateProfileInt(_T("Control"), _T("MouseSensitivity"), config.mouse_sensitivity, config_path);
 	#ifdef USE_SOUND_TYPE
 		MyWritePrivateProfileInt(_T("Control"), _T("SoundType"), config.sound_type, config_path);
 	#endif

--- a/src/config.h
+++ b/src/config.h
@@ -98,6 +98,8 @@ typedef struct {
 	#if defined(USE_SHARED_DLL) || defined(USE_JOYSTICK_TYPE)
 		int joystick_type;
 	#endif
+	bool mouse_enabled;
+	int mouse_sensitivity; // percentage: 50, 75, 100, 150, 200, or 300
 	#if defined(USE_SHARED_DLL) || defined(USE_SOUND_TYPE)
 		int sound_type;
 	#endif
@@ -279,4 +281,3 @@ typedef struct {
 extern DLL_PREFIX config_t config;
 
 #endif
-

--- a/src/emu.cpp
+++ b/src/emu.cpp
@@ -1626,6 +1626,10 @@ const uint32_t *EMU::get_joy_buffer() { return (const uint32_t *)joy_status; }
 const int32_t *EMU::get_mouse_buffer() {
   return (const int32_t *)osd->get_mouse_buffer();
 }
+
+void EMU::consume_mouse_delta(int32_t &dx, int32_t &dy) {
+  osd->consume_mouse_delta(dx, dy);
+}
 #endif
 
 // ----------------------------------------------------------------------------
@@ -3113,9 +3117,13 @@ void EMU::load_state(const _TCHAR *file_path) {
 bool EMU::load_state_tmp(const _TCHAR *file_path) {
   bool result = false;
   FILEIO *fio = new FILEIO();
-  // Host sound settings are not restored from state.
+  // Host sound and input settings are not restored from state.
   const int host_sound_frequency = sanitize_sound_frequency_index(config.sound_frequency);
   const int host_sound_latency = sanitize_sound_latency_index(config.sound_latency);
+  const bool host_mouse_enabled = config.mouse_enabled;
+#ifdef USE_JOYSTICK_TYPE
+  const int host_joystick_type = config.joystick_type;
+#endif
   osd->lock_vm();
 #ifdef USE_ZLIB
   //	if(config.compress_state) {
@@ -3132,6 +3140,10 @@ bool EMU::load_state_tmp(const _TCHAR *file_path) {
       if (process_config_state((void *)fio, true)) {
         config.sound_frequency = host_sound_frequency;
         config.sound_latency = host_sound_latency;
+        config.mouse_enabled = host_mouse_enabled;
+#ifdef USE_JOYSTICK_TYPE
+        config.joystick_type = host_joystick_type;
+#endif
         // load inserted medias
 #ifdef USE_CART
         fio->Fread(&cart_status, sizeof(cart_status), 1);

--- a/src/emu.h
+++ b/src/emu.h
@@ -271,6 +271,7 @@ public:
 #endif
 #ifdef USE_MOUSE
   const int32_t *get_mouse_buffer();
+  void consume_mouse_delta(int32_t &dx, int32_t &dy);
 #endif
 
   // screen

--- a/src/sdl3/osd.cpp
+++ b/src/sdl3/osd.cpp
@@ -120,7 +120,13 @@ namespace Lang {
   static constexpr Msg Screen = {"Screen", "画面", "屏幕", "화면", "Pantalla", "Écran"};
   static constexpr Msg Fullscreen = {"Fullscreen", "フルスクリーン", "全屏", "전체 화면", "Pantalla completa", "Plein écran"};
   static constexpr Msg SaveScreenshot = {"Save Screenshot...", "スクリーンショット保存...", "保存截图...", "스크린샷 저장...", "Guardar captura de pantalla...", "Enregistrer une capture d'écran..."};
-  static constexpr Msg Keyboard = {"Keyboard", "キーボード", "键盘", "키보드", "Teclado", "Clavier"};
+  static constexpr Msg Input = {"Input", "入力", "输入", "입력", "Entrada", "Entrée"};
+  static constexpr Msg EnableMouseInput = {"Enable Mouse Input", "マウス入力を有効化", "启用鼠标输入", "마우스 입력 사용", "Activar entrada de ratón", "Activer l'entrée souris"};
+  static constexpr Msg ReleaseMouseCaptureHint = {"F12 releases mouse capture", "F12でマウスキャプチャを解放", "按F12释放鼠标捕获", "F12로 마우스 캡처 해제", "F12 libera la captura del ratón", "F12 libère la capture de la souris"};
+  static constexpr Msg MouseMode = {"Mouse Mode", "マウス方式", "鼠标模式", "마우스 모드", "Modo de ratón", "Mode souris"};
+  static constexpr Msg Mouse = {"Bus Mouse (PC-8872)", "バスマウス (PC-8872)", "总线鼠标 (PC-8872)", "버스 마우스 (PC-8872)", "Ratón de bus (PC-8872)", "Souris bus (PC-8872)"};
+  static constexpr Msg MouseAsJoystick = {"Mouse as Joystick", "マウス擬似ジョイスティック", "鼠标模拟游戏杆", "마우스 조이스틱 모드", "Ratón como joystick", "Souris comme joystick"};
+  static constexpr Msg MouseSensitivity = {"Mouse Sensitivity", "マウス感度", "鼠标灵敏度", "마우스 감도", "Sensibilidad del ratón", "Sensibilité de la souris"};
   static constexpr Msg MapCursorToNumpad = {"Map cursor keys to Numpad", "カーソルキーをテンキーに割当", "映射方向键到数字键盘", "방향키를 숫자 키패드에 할당", "Mapear cursores al teclado numérico", "Mapper les flèches sur le pavé numérique"};
   static constexpr Msg MapDigitToNumpad = {"Map number keys to Numpad", "数字キーをテンキーに割当", "映射数字键到数字键盘", "숫자 키를 숫자 키패드に 할당", "Mapear números al teclado numérico", "Mapper les chiffres sur le pavé numérique"};
   static constexpr Msg SamplingFrequency = {"Sampling Frequency", "サンプリング周波数", "采样率", "샘플링 주파수", "Frecuencia de muestreo", "Fréquence d'échantillonnage"};
@@ -144,6 +150,26 @@ namespace Lang {
   static constexpr Msg FPSView = {"FPS: %.1f", "表示: %.1f", "帧率: %.1f", "표시: %.1f", "FPS: %.1f", "IPS: %.1f"};
   static constexpr Msg FPSCore = {"Core: %.1f", "実行: %.1f", "核心: %.1f", "실행: %.1f", "Núcleo: %.1f", "Cœur: %.1f"};
 }
+
+// Alpha mask derived from the supplied mouse.png and reduced to 11x16.
+static constexpr uint8_t kMouseIconAlpha[11 * 16] = {
+  0x00, 0x03, 0x30, 0x7b, 0xbc, 0x1f, 0x8b, 0xa2, 0x4f, 0x11, 0x00,
+  0x05, 0x80, 0x94, 0x54, 0xa3, 0x92, 0xbd, 0x55, 0x79, 0xa1, 0x34,
+  0x25, 0x99, 0x07, 0x00, 0x8d, 0x84, 0xb4, 0x19, 0x00, 0x5a, 0x80,
+  0x48, 0x7d, 0x00, 0x00, 0x95, 0xc9, 0xd2, 0x1b, 0x00, 0x2a, 0xa3,
+  0x65, 0x62, 0x00, 0x00, 0x88, 0xda, 0xc4, 0x1a, 0x00, 0x0f, 0xad,
+  0x76, 0x71, 0x00, 0x00, 0x82, 0xe8, 0xc0, 0x1b, 0x00, 0x0b, 0xad,
+  0xcd, 0xa6, 0x00, 0x00, 0x75, 0xd3, 0xb8, 0x13, 0x00, 0x16, 0xaa,
+  0xa5, 0xc4, 0x0f, 0x00, 0x19, 0xb2, 0x54, 0x00, 0x00, 0x3b, 0xb0,
+  0x81, 0xf9, 0x2c, 0x00, 0x00, 0x6b, 0x1f, 0x00, 0x00, 0xa0, 0xc3,
+  0x51, 0xcf, 0x4a, 0x00, 0x00, 0x16, 0x07, 0x00, 0x00, 0x9f, 0xc1,
+  0x35, 0xed, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x8d, 0xd0,
+  0x30, 0xff, 0x2e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x70, 0xf5,
+  0x1f, 0xd6, 0x1e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x56, 0xdc,
+  0x00, 0x93, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x9f, 0x6e,
+  0x00, 0x18, 0xa5, 0x78, 0x21, 0x0b, 0x0d, 0x2e, 0x93, 0x88, 0x07,
+  0x00, 0x00, 0x13, 0x7e, 0xb8, 0xb8, 0xb8, 0xb1, 0x62, 0x05, 0x00
+};
 
 // Get user home directory
 static std::string get_home_directory() {
@@ -397,6 +423,12 @@ OSD::OSD() {
   vm_screen_buffer = NULL;
   vm_screen_width = 0;
   vm_screen_height = 0;
+  vm_screen_rect = {0, 0, 0, 0};
+  vm_screen_rect_valid = false;
+  mouse_icon_texture = NULL;
+  mouse_remainder_x = 0;
+  mouse_remainder_y = 0;
+  mouse_enabled = false;
   show_state_dialog = false;
   state_dialog_selected = 0;
   for (int i = 0; i < 10; i++) {
@@ -543,6 +575,7 @@ void OSD::initialize(int rate, int samples) {
   OSD_LOG("Calling initialize_imgui()...");
   initialize_imgui();
   OSD_LOG("initialize_imgui() done, imgui_initialized=%d", imgui_initialized);
+  initialize_mouse_icon();
 
   if (vm_screen_buffer) {
     set_vm_screen_size(640, 400, window_width, window_height, window_width, window_height);
@@ -551,7 +584,9 @@ void OSD::initialize(int rate, int samples) {
 }
 
 void OSD::release() {
+  disable_mouse();
   release_state_thumbnails();
+  release_mouse_icon();
   release_sound();
   release_imgui();
   if (joystick) {
@@ -803,6 +838,10 @@ void OSD::update_input() {
     if (event.type == SDL_EVENT_QUIT) {
       terminated = true;
     }
+    if (event.type == SDL_EVENT_WINDOW_FOCUS_LOST) {
+      disable_mouse();
+      clear_all_pressed_keys();
+    }
     if (event.type == SDL_EVENT_DROP_FILE) {
       if (event.drop.data) {
         pending_dd_path = event.drop.data;
@@ -825,6 +864,14 @@ void OSD::update_input() {
 void OSD::handle_event(const SDL_Event &event, bool block_vm_keydown) {
   if (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP) {
     bool down = (event.type == SDL_EVENT_KEY_DOWN);
+    if (event.key.scancode == SDL_SCANCODE_F12 && mouse_enabled) {
+      if (down) {
+        disable_mouse();
+        show_menu = true;
+        last_ui_interaction_tick = SDL_GetTicks();
+      }
+      return;
+    }
     int vk = 0;
     switch (event.key.scancode) {
     case SDL_SCANCODE_ESCAPE: vk = 0x1B; break;
@@ -982,15 +1029,83 @@ void OSD::handle_event(const SDL_Event &event, bool block_vm_keydown) {
       }
     }
   } else if (event.type == SDL_EVENT_MOUSE_MOTION) {
-    mouse_status[0] += (int32_t)event.motion.xrel;
-    mouse_status[1] += (int32_t)event.motion.yrel;
-    last_ui_interaction_tick = SDL_GetTicks(); // Reset UI visibility timer
+    if (mouse_enabled) {
+      const double sensitivity = config.mouse_sensitivity / 100.0;
+      const double scaled_x = event.motion.xrel * sensitivity + mouse_remainder_x;
+      const double scaled_y = event.motion.yrel * sensitivity + mouse_remainder_y;
+      const int32_t whole_x = (int32_t)scaled_x;
+      const int32_t whole_y = (int32_t)scaled_y;
+      mouse_status[0] += whole_x;
+      mouse_status[1] += whole_y;
+      mouse_remainder_x = scaled_x - whole_x;
+      mouse_remainder_y = scaled_y - whole_y;
+    } else {
+      last_ui_interaction_tick = SDL_GetTicks();
+    }
   } else if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN || event.type == SDL_EVENT_MOUSE_BUTTON_UP) {
     bool down = (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN);
-    if (event.button.button == SDL_BUTTON_LEFT) mouse_status[2] = down ? 1 : 0;
-    if (event.button.button == SDL_BUTTON_RIGHT) mouse_status[3] = down ? 1 : 0;
-    last_ui_interaction_tick = SDL_GetTicks(); // Reset UI visibility timer
+    if (!mouse_enabled) {
+      last_ui_interaction_tick = SDL_GetTicks();
+      if (down && event.button.button == SDL_BUTTON_LEFT &&
+          config.mouse_enabled && vm_screen_rect_valid &&
+          event.button.x >= vm_screen_rect.x &&
+          event.button.x < vm_screen_rect.x + vm_screen_rect.w &&
+          event.button.y >= vm_screen_rect.y &&
+          event.button.y < vm_screen_rect.y + vm_screen_rect.h) {
+        enable_mouse();
+      }
+      return;
+    }
+    if (event.button.button == SDL_BUTTON_LEFT) {
+      if (down) mouse_status[2] |= 0x01;
+      else mouse_status[2] &= ~0x01;
+    } else if (event.button.button == SDL_BUTTON_RIGHT) {
+      if (down) mouse_status[2] |= 0x02;
+      else mouse_status[2] &= ~0x02;
+    }
   }
+}
+
+void OSD::clear_mouse_state() {
+  mouse_status[0] = 0;
+  mouse_status[1] = 0;
+  mouse_status[2] = 0;
+  mouse_status[3] = 0;
+  mouse_remainder_x = 0;
+  mouse_remainder_y = 0;
+}
+
+void OSD::enable_mouse() {
+  if (mouse_enabled || !window || !config.mouse_enabled) return;
+  clear_mouse_state();
+  if (SDL_SetWindowRelativeMouseMode(window, true)) {
+    mouse_enabled = true;
+  } else {
+    OSD_LOG("Failed to enable relative mouse mode: %s", SDL_GetError());
+  }
+}
+
+void OSD::disable_mouse() {
+  if (mouse_enabled && window) {
+    if (!SDL_SetWindowRelativeMouseMode(window, false)) {
+      OSD_LOG("Failed to disable relative mouse mode: %s", SDL_GetError());
+    }
+  }
+  mouse_enabled = false;
+  clear_mouse_state();
+  if (window) SDL_ShowCursor();
+}
+
+void OSD::toggle_mouse() {
+  if (mouse_enabled) disable_mouse();
+  else enable_mouse();
+}
+
+void OSD::consume_mouse_delta(int32_t &dx, int32_t &dy) {
+  dx = mouse_status[0];
+  dy = mouse_status[1];
+  mouse_status[0] = 0;
+  mouse_status[1] = 0;
 }
 
 void OSD::clear_all_pressed_keys() {
@@ -1295,6 +1410,8 @@ int OSD::draw_screen() {
     }
 
     SDL_FRect dest_rect = { draw_x, draw_y, draw_w, draw_h };
+    vm_screen_rect = dest_rect;
+    vm_screen_rect_valid = true;
     SDL_RenderTexture(renderer, screen_texture, NULL, &dest_rect);
 
     process_pending_insert();
@@ -1496,6 +1613,18 @@ void OSD::draw_status_bar() {
         ImGui::Text("%s", clock_text);
       }
       right -= (clock_w + 16.0f);
+    }
+
+    if (mouse_enabled && mouse_icon_texture) {
+      const float icon_w = 11.0f;
+      const float icon_h = 16.0f;
+      const float icon_x = right - icon_w;
+      const float icon_y = ImGui::GetWindowPos().y +
+                           (ImGui::GetWindowHeight() - icon_h) * 0.5f - 2.0f;
+      ImGui::GetWindowDrawList()->AddImage(
+          (ImTextureID)(uintptr_t)mouse_icon_texture,
+          ImVec2(icon_x, icon_y),
+          ImVec2(icon_x + icon_w, icon_y + icon_h));
     }
 
     ImGui::End();
@@ -2014,6 +2143,38 @@ void OSD::release_imgui() {
   imgui_initialized = false;
 }
 
+void OSD::initialize_mouse_icon() {
+  if (!renderer || mouse_icon_texture) return;
+
+  uint8_t pixels[11 * 16 * 4];
+  for (size_t i = 0; i < sizeof(kMouseIconAlpha); i++) {
+    pixels[i * 4 + 0] = 224;
+    pixels[i * 4 + 1] = 224;
+    pixels[i * 4 + 2] = 224;
+    pixels[i * 4 + 3] = kMouseIconAlpha[i];
+  }
+  SDL_Surface *surface = SDL_CreateSurfaceFrom(
+      11, 16, SDL_PIXELFORMAT_RGBA32, pixels, 11 * 4);
+  if (!surface) {
+    OSD_LOG("Failed to create mouse icon surface: %s", SDL_GetError());
+    return;
+  }
+  mouse_icon_texture = SDL_CreateTextureFromSurface(renderer, surface);
+  SDL_DestroySurface(surface);
+  if (!mouse_icon_texture) {
+    OSD_LOG("Failed to create mouse icon texture: %s", SDL_GetError());
+  } else {
+    SDL_SetTextureScaleMode(mouse_icon_texture, SDL_SCALEMODE_LINEAR);
+  }
+}
+
+void OSD::release_mouse_icon() {
+  if (mouse_icon_texture) {
+    SDL_DestroyTexture(mouse_icon_texture);
+    mouse_icon_texture = NULL;
+  }
+}
+
 bool OSD::draw_menu_contents() {
     bool menu_tree_open = false;
     if (ImGui::BeginMenu(Lang::Control)) {
@@ -2208,7 +2369,43 @@ bool OSD::draw_menu_contents() {
         if (ImGui::MenuItem(Lang::SaveScreenshot)) { show_screenshot_dialog(); }
         ImGui::EndMenu();
       }
-      if (ImGui::BeginMenu(Lang::Keyboard)) {
+      if (ImGui::BeginMenu(Lang::Input)) {
+        if (ImGui::MenuItem(Lang::EnableMouseInput, NULL,
+                            config.mouse_enabled)) {
+          config.mouse_enabled = !config.mouse_enabled;
+          if (!config.mouse_enabled) disable_mouse();
+          if (vm) vm->update_config();
+        }
+        ImGui::MenuItem(Lang::ReleaseMouseCaptureHint, NULL, false, false);
+        if (ImGui::BeginMenu(Lang::MouseMode, config.mouse_enabled)) {
+          if (ImGui::MenuItem(Lang::Mouse, NULL, config.joystick_type == 1)) {
+            disable_mouse();
+            config.joystick_type = 1;
+            if (vm) vm->update_config();
+          }
+          if (ImGui::MenuItem(Lang::MouseAsJoystick, NULL,
+                              config.joystick_type == 2)) {
+            disable_mouse();
+            config.joystick_type = 2;
+            if (vm) vm->update_config();
+          }
+          ImGui::EndMenu();
+        }
+        if (ImGui::BeginMenu(Lang::MouseSensitivity,
+                             config.mouse_enabled)) {
+          static const int sensitivity_values[] = {50, 75, 100, 150, 200, 300};
+          static const char *sensitivity_labels[] = {
+              "0.5x", "0.75x", "1.0x", "1.5x", "2.0x", "3.0x"
+          };
+          for (int i = 0; i < 6; i++) {
+            if (ImGui::MenuItem(sensitivity_labels[i], NULL,
+                                config.mouse_sensitivity == sensitivity_values[i])) {
+              config.mouse_sensitivity = sensitivity_values[i];
+            }
+          }
+          ImGui::EndMenu();
+        }
+        ImGui::Separator();
         if (ImGui::MenuItem(Lang::MapCursorToNumpad, NULL, config.cursor_as_numpad)) {
           config.cursor_as_numpad = !config.cursor_as_numpad;
         }

--- a/src/sdl3/osd.h
+++ b/src/sdl3/osd.h
@@ -55,6 +55,9 @@ private:
   uint8_t key_status[256];
   uint32_t joy_status[4];
   int32_t mouse_status[8];
+  double mouse_remainder_x;
+  double mouse_remainder_y;
+  bool mouse_enabled;
   bool key_shift_pressed, key_shift_released;
   bool key_caps_locked;
 
@@ -68,6 +71,9 @@ private:
   scrntype_t *vm_screen_buffer;
   int vm_screen_width, vm_screen_height;
   int window_width, window_height;
+  SDL_FRect vm_screen_rect;
+  bool vm_screen_rect_valid;
+  SDL_Texture *mouse_icon_texture;
 
   // Sound
   void initialize_sound(int rate, int samples);
@@ -143,6 +149,9 @@ private:
   _TCHAR fd1_path[_MAX_PATH];
   _TCHAR fd2_path[_MAX_PATH];
   void clear_all_pressed_keys();
+  void clear_mouse_state();
+  void initialize_mouse_icon();
+  void release_mouse_icon();
 
 public:
   OSD();
@@ -200,10 +209,11 @@ public:
   void key_up(int code, bool extended);
   uint8_t *get_key_buffer() { return key_status; }
   void key_lost_focus() {}
-  void enable_mouse() {}
-  void disable_mouse() {}
-  void toggle_mouse() {}
-  bool is_mouse_enabled() { return false; }
+  void enable_mouse();
+  void disable_mouse();
+  void toggle_mouse();
+  bool is_mouse_enabled() { return mouse_enabled; }
+  void consume_mouse_delta(int32_t &dx, int32_t &dy);
   int32_t *get_mouse_buffer() { return mouse_status; }
   uint32_t *get_joy_buffer() { return joy_status; }
   // Native key simulation

--- a/src/vm/pc8801/pc88.cpp
+++ b/src/vm/pc8801/pc88.cpp
@@ -39,7 +39,7 @@
 
 #define DEVICE_JOYSTICK 0
 #define DEVICE_MOUSE 1
-#define DEVICE_JOYMOUSE 2 // not supported yet
+#define DEVICE_JOYMOUSE 2
 
 #define EVENT_TIMER 0
 #define EVENT_BUSREQ 1
@@ -129,8 +129,6 @@
 #else
 #define Port40_GHSM false
 #endif
-#define Port40_JOP1 (port[0x40] & 0x40)
-
 #ifdef SUPPORT_PC88_OPN1
 #define Port44_OPNCH port[0x44]
 #endif
@@ -717,6 +715,7 @@ void PC88::reset() {
   mouse_strobe_clock = get_current_clock();
   mouse_phase = -1;
   mouse_dx = mouse_dy = mouse_lx = mouse_ly = 0;
+  mouse_joy_latch = -1;
 #endif
 
   // interrupt
@@ -1253,10 +1252,10 @@ void PC88::write_io8(uint32_t addr, uint32_t data) {
 #endif
     beep_on = ((data & 0x20) != 0);
 #ifdef SUPPORT_PC88_JOYSTICK
-    if (mod & 0x40) {
-      if (Port40_JOP1 &&
-          (mouse_phase == -1 ||
-           get_passed_clock(mouse_strobe_clock) > mouse_strobe_clock_lim)) {
+    if ((mod & 0x40) && config.mouse_enabled &&
+        config.joystick_type == DEVICE_MOUSE) {
+      if (mouse_phase == -1 ||
+          get_passed_clock(mouse_strobe_clock) > mouse_strobe_clock_lim) {
         mouse_phase = 0; // mouse_dx = mouse_dy = 0;
       } else {
         mouse_phase = (mouse_phase + 1) & 3;
@@ -1915,7 +1914,8 @@ uint32_t PC88::read_io8_debug(uint32_t addr)
     if (d_opn1 != NULL) {
       if (Port44_OPNCH == 14) {
 #ifdef SUPPORT_PC88_JOYSTICK
-        if (config.joystick_type == DEVICE_JOYSTICK) {
+        if (!config.mouse_enabled ||
+            config.joystick_type == DEVICE_JOYSTICK) {
           return (~(joystick_status[0] >> 0) & 0x0f) | 0xf0;
         } else if (config.joystick_type == DEVICE_MOUSE) {
           switch (mouse_phase) {
@@ -1929,14 +1929,18 @@ uint32_t PC88::read_io8_debug(uint32_t addr)
             return ((mouse_ly >> 0) & 0x0f) | 0xf0;
           }
           return 0xff; // ???
+        } else if (config.joystick_type == DEVICE_JOYMOUSE) {
+          return read_mouse_joy();
         }
 #endif
         return 0xff;
       } else if (Port44_OPNCH == 15) {
 #ifdef SUPPORT_PC88_JOYSTICK
-        if (config.joystick_type == DEVICE_JOYSTICK) {
+        if (!config.mouse_enabled ||
+            config.joystick_type == DEVICE_JOYSTICK) {
           return (~(joystick_status[0] >> 4) & 0x03) | 0xfc;
-        } else if (config.joystick_type == DEVICE_MOUSE) {
+        } else if (config.joystick_type == DEVICE_MOUSE ||
+                   config.joystick_type == DEVICE_JOYMOUSE) {
           return (~mouse_status[2] & 0x03) | 0xfc;
         }
 #endif
@@ -2111,7 +2115,8 @@ uint32_t PC88::read_io8_debug(uint32_t addr)
     if (d_opn2 != NULL) {
       if (PortA8_OPNCH == 14) {
 #ifdef SUPPORT_PC88_JOYSTICK
-        if (config.joystick_type == DEVICE_JOYSTICK) {
+        if (!config.mouse_enabled ||
+            config.joystick_type == DEVICE_JOYSTICK) {
           return (~(joystick_status[0] >> 0) & 0x0f) | 0xf0;
         } else if (config.joystick_type == DEVICE_MOUSE) {
           switch (mouse_phase) {
@@ -2125,14 +2130,18 @@ uint32_t PC88::read_io8_debug(uint32_t addr)
             return ((mouse_ly >> 0) & 0x0f) | 0xf0;
           }
           return 0xff; // ???
+        } else if (config.joystick_type == DEVICE_JOYMOUSE) {
+          return read_mouse_joy();
         }
 #endif
         return 0xff;
       } else if (PortA8_OPNCH == 15) {
 #ifdef SUPPORT_PC88_JOYSTICK
-        if (config.joystick_type == DEVICE_JOYSTICK) {
+        if (!config.mouse_enabled ||
+            config.joystick_type == DEVICE_JOYSTICK) {
           return (~(joystick_status[0] >> 4) & 0x03) | 0xfc;
-        } else if (config.joystick_type == DEVICE_MOUSE) {
+        } else if (config.joystick_type == DEVICE_MOUSE ||
+                   config.joystick_type == DEVICE_JOYMOUSE) {
           return (~mouse_status[2] & 0x03) | 0xfc;
         }
 #endif
@@ -2250,6 +2259,9 @@ void PC88::update_config() {
   cpu_clock_high_fe2 = (config.cpu_type == 2); // 8MHz (FE2/MC)
 #else
   cpu_clock_low = true;
+#endif
+#ifdef SUPPORT_PC88_JOYSTICK
+  mouse_strobe_clock_lim = (int)((cpu_clock_low ? 720 : 1440) * 1.25);
 #endif
   
   // Re-calculate event manager CPU clock
@@ -2779,10 +2791,35 @@ void PC88::event_frame() {
   crtc.update_blink();
 
 #ifdef SUPPORT_PC88_JOYSTICK
-  mouse_dx += mouse_status[0];
-  mouse_dy += mouse_status[1];
+  int32_t host_mouse_dx = 0;
+  int32_t host_mouse_dy = 0;
+  emu->consume_mouse_delta(host_mouse_dx, host_mouse_dy);
+  if (config.mouse_enabled) {
+    mouse_dx += host_mouse_dx;
+    mouse_dy += host_mouse_dy;
+  } else {
+    mouse_dx = mouse_dy = 0;
+  }
+  // Joy-mouse movement is consumed lazily when OPN port A is read. VSync only
+  // releases the previous direction latch, matching M88/Bubilator88 behavior.
+  mouse_joy_latch = -1;
 #endif
 }
+
+#ifdef SUPPORT_PC88_JOYSTICK
+uint8_t PC88::read_mouse_joy() {
+  if (mouse_joy_latch < 0) {
+    static constexpr int kJoyThreshold = 3;
+    mouse_joy_latch = 0xff;
+    if (mouse_dy <= -kJoyThreshold) mouse_joy_latch &= ~0x01; // up
+    if (mouse_dy >=  kJoyThreshold) mouse_joy_latch &= ~0x02; // down
+    if (mouse_dx <= -kJoyThreshold) mouse_joy_latch &= ~0x04; // left
+    if (mouse_dx >=  kJoyThreshold) mouse_joy_latch &= ~0x08; // right
+    mouse_dx = mouse_dy = 0;
+  }
+  return (uint8_t)mouse_joy_latch;
+}
+#endif
 
 void PC88::event_vline(int v, int clock) {
   int disp_line = crtc.height * crtc.char_height;
@@ -4578,6 +4615,7 @@ bool PC88::process_state(FILEIO *state_fio, bool loading) {
   state_fio->StateValue(mouse_dy);
   state_fio->StateValue(mouse_lx);
   state_fio->StateValue(mouse_ly);
+  if (loading) mouse_joy_latch = -1;
 #endif
   state_fio->StateValue(intr_req);
 #ifdef SUPPORT_PC88_OPN1

--- a/src/vm/pc8801/pc88.h
+++ b/src/vm/pc8801/pc88.h
@@ -337,6 +337,8 @@ private:
 	int mouse_phase;
 	int mouse_dx, mouse_dy;
 	int mouse_lx, mouse_ly;
+	int mouse_joy_latch;
+	uint8_t read_mouse_joy();
 #endif
 	
 	// intterrupt
@@ -623,4 +625,3 @@ public:
 };
 
 #endif
-


### PR DESCRIPTION
## Summary

- add PC-8872 bus mouse and mouse-as-joystick input routing through the OPN general-purpose I/O ports
- add SDL3 relative mouse capture, F12/focus-loss release behavior, sensitivity scaling, and a capture status icon
- consolidate mouse and keyboard options under `Host > Input`, with persistent mouse enable, mode, and sensitivity settings
- keep host mouse settings unchanged when loading save states

## Why

The core contained part of the PC-88 mouse protocol, but SDL3 did not provide capture or one-shot relative movement consumption, and the OPN routing/strobe behavior was incomplete for software using the PC-8872 interface. This change connects host input to the existing protocol and aligns the behavior with the Bubilator88 reference implementation.

## User impact

Users can enable mouse input, select bus mouse or mouse-as-joystick mode, choose sensitivity, and click the VM display to capture the pointer. F12 or focus loss releases capture. The status bar shows a mouse icon only while captured.

## Validation

- `cmake --build build -j4`
- `git diff --check`
- manual verification with PC-88 mouse-compatible software
