### PR TITLE
[codex] Update SDL3 and VS2026 Windows build

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -9,6 +9,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+env:
+  SDL3_VERSION: 3.4.10
+
 jobs:
   build-windows:
     runs-on: windows-2022
@@ -45,7 +48,7 @@ jobs:
 
           # Copy correct architecture SDL3.dll from third_party
           $arch = "${{ matrix.arch }}".ToLower()
-          $sdlDll = "third_party/SDL3-3.4.2/lib/$arch/SDL3.dll"
+          $sdlDll = "third_party/SDL3-$env:SDL3_VERSION/lib/$arch/SDL3.dll"
           if (Test-Path $sdlDll) {
             Copy-Item $sdlDll $packageDir -Force
             Write-Host "Copied SDL3.dll from $sdlDll"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-windows:
-    runs-on: windows-2022
+    runs-on: windows-2025
     strategy:
       matrix:
         arch: [x64, ARM64]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ set(SDL_SOURCES
 # Windows       : use official binary
 # =====================================
 
+set(BUBIC_SDL3_VERSION "3.4.10")
+
 if(WIN32)
     # Windows: use prebuilt SDL3 (DLL)
     find_package(SDL3 REQUIRED CONFIG)
@@ -82,7 +84,7 @@ else()
     FetchContent_Declare(
         SDL3
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-        GIT_TAG        release-3.4.8
+        GIT_TAG        release-${BUBIC_SDL3_VERSION}
         GIT_SHALLOW    TRUE
     )
 

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,7 +1,7 @@
 # build_windows.ps1 — BubiC-8801MA ローカルビルド (Windows / MSVC)
 # 使い方: .\scripts\build_windows.ps1 [-BuildType Debug|Release] [-Arch x64|ARM64]
 #
-# 前提: Visual Studio 2019/2022 (C++ ワークロード) がインストール済みであること
+# 前提: Visual Studio 2026 (C++ ワークロード) がインストール済みであること
 param(
     [string]$BuildType = "Release",
     [string]$Arch      = "x64"
@@ -9,6 +9,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $BuildDir = "build_$Arch"
+$SdlVersion = "3.4.10"
 
 Write-Host "=== BubiC-8801MA Windows Build ===" -ForegroundColor Cyan
 Write-Host "  Build type : $BuildType"
@@ -17,27 +18,26 @@ Write-Host ""
 
 # ==========================================
 # SDL3 Policy (Windows)
-# Use official SDL release 3.4.2 (no source build)
+# Use official SDL release (no source build)
 # Expect extracted SDL next to repository:
-#   third_party/SDL3-3.4.2/
+#   third_party/SDL3-$SdlVersion/
 # ==========================================
 
 $ProjectRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
-$SdlRoot = Join-Path $ProjectRoot "third_party\SDL3-3.4.2"
+$SdlRoot = Join-Path $ProjectRoot "third_party\SDL3-$SdlVersion"
 
 if (-not (Test-Path $SdlRoot)) {
-    Write-Host "[INFO] SDL3-3.4.2 not found. Downloading official release..." -ForegroundColor Yellow
+    Write-Host "[INFO] SDL3-$SdlVersion not found. Downloading official release..." -ForegroundColor Yellow
 
-    $version = "3.4.2"
-    $baseUrl = "https://github.com/libsdl-org/SDL/releases/download/release-$version"
-    $zipName = "SDL3-devel-$version-VC.zip"
+    $baseUrl = "https://github.com/libsdl-org/SDL/releases/download/release-$SdlVersion"
+    $zipName = "SDL3-devel-$SdlVersion-VC.zip"
     $zipPath = Join-Path $ProjectRoot $zipName
 
     Invoke-WebRequest -Uri "$baseUrl/$zipName" -OutFile $zipPath
 
     Expand-Archive $zipPath -DestinationPath $ProjectRoot -Force
 
-    $extracted = Get-ChildItem -Path $ProjectRoot -Directory -Filter "SDL3-$version*" | Select-Object -First 1
+    $extracted = Get-ChildItem -Path $ProjectRoot -Directory -Filter "SDL3-$SdlVersion*" | Select-Object -First 1
     if ($null -eq $extracted) {
         throw "Failed to extract SDL3 archive."
     }
@@ -47,11 +47,11 @@ if (-not (Test-Path $SdlRoot)) {
 
     Remove-Item $zipPath -Force
 
-    Write-Host "[INFO] SDL3-3.4.2 downloaded and prepared." -ForegroundColor Green
+    Write-Host "[INFO] SDL3-$SdlVersion downloaded and prepared." -ForegroundColor Green
 }
 
 if (-not (Test-Path $SdlRoot)) {
-    throw "SDL3-3.4.2 setup failed."
+    throw "SDL3-$SdlVersion setup failed."
 }
 
 $SdlCMakePath = Join-Path $SdlRoot "cmake"
@@ -60,9 +60,51 @@ if (-not (Test-Path $SdlCMakePath)) {
 }
 
 $CMakeArch = if ($Arch -eq "ARM64") { "ARM64" } else { "x64" }
+$CMakeGenerator = "Visual Studio 18 2026"
+
+function Get-CMakeCacheValue {
+    param(
+        [string[]]$Cache,
+        [string]$Key
+    )
+
+    $match = $Cache | Select-String -Pattern "^$([regex]::Escape($Key)):INTERNAL=(.*)$" | Select-Object -First 1
+    if ($null -eq $match) {
+        return ""
+    }
+
+    return $match.Matches.Groups[1].Value
+}
+
+function Clear-CMakeConfigureCache {
+    param([string]$CachePath)
+
+    Write-Host "[INFO] Removing stale CMake cache: $CachePath" -ForegroundColor Yellow
+    Remove-Item -LiteralPath $CachePath -Force
+
+    $cmakeFilesDir = Join-Path (Split-Path -Parent $CachePath) "CMakeFiles"
+    if (Test-Path $cmakeFilesDir) {
+        Remove-Item -LiteralPath $cmakeFilesDir -Recurse -Force
+    }
+}
+
+if (Test-Path $BuildDir) {
+    $cmakeCaches = Get-ChildItem -LiteralPath $BuildDir -Recurse -Filter "CMakeCache.txt" -File
+
+    foreach ($cmakeCache in $cmakeCaches) {
+        $cache = Get-Content -LiteralPath $cmakeCache.FullName
+        $cachedGenerator = Get-CMakeCacheValue -Cache $cache -Key "CMAKE_GENERATOR"
+        $cachedPlatform = Get-CMakeCacheValue -Cache $cache -Key "CMAKE_GENERATOR_PLATFORM"
+        $isTopLevelCache = ($cmakeCache.FullName -eq (Join-Path (Resolve-Path $BuildDir) "CMakeCache.txt"))
+
+        if (($cachedGenerator -ne $CMakeGenerator) -or ($isTopLevelCache -and ($cachedPlatform -ne $CMakeArch))) {
+            Clear-CMakeConfigureCache -CachePath $cmakeCache.FullName
+        }
+    }
+}
 
 cmake -S . -B $BuildDir `
-    -G "Visual Studio 17 2022" `
+    -G $CMakeGenerator `
     -A $CMakeArch `
     -DCMAKE_BUILD_TYPE=$BuildType `
     -DCMAKE_PREFIX_PATH="$SdlCMakePath"


### PR DESCRIPTION
## Summary

- update SDL3 to 3.4.10 across Windows packaging and Linux/macOS FetchContent builds
- centralize SDL version values in the Windows script, CMake, and Windows workflow
- switch the Windows local build generator to Visual Studio 18 2026
- automatically clear stale top-level and FetchContent CMake caches when the generator or platform changes

## Why

Existing build directories could retain Visual Studio 2022 or platform-less CMake caches. After switching the script to Visual Studio 2026 with an explicit architecture, those caches caused generator/platform mismatch errors. The SDL version was also inconsistent between Windows and non-Windows builds.

## Impact

Windows local builds now use Visual Studio 2026 and SDL 3.4.10. Linux and macOS FetchContent builds also target SDL 3.4.10. Windows CI packages the matching SDL3 DLL.

## Validation

- PowerShell parser check passed for `scripts/build_windows.ps1`
- `git diff --cached --check` passed
- `./scripts/build_windows.ps1` completed successfully for x64 Release
- generated `build_x64/Release/BubiC-8801MA.exe`
